### PR TITLE
Interactive tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "docs": "cd packages/docs && nuxt dev",
     "app": "cd packages/app && nuxt dev",
-    "electron:app": "cd packages/app && ELECTRON=true nuxt dev"
+    "app:electron": "cd packages/app && ELECTRON=true nuxt dev"
   },
   "devDependencies": {
     "lerna": "^6.1.0"

--- a/packages/app/components/TodoCount.vue
+++ b/packages/app/components/TodoCount.vue
@@ -2,32 +2,20 @@
 import { useTodosStore } from '@/stores/todos'
 
 const props = defineProps([
-  'value',
   'todo',
   'parent',
 ])
 
-const count = ref(props.value)
-
-const increment = () => {
-  count.value++
-  updateTodoDescription(
-    props.todo.id,
-    `${props.todo.description}`.replace(/count:[^\s:]+/, `count:${count.value}`),
-    props.parent
-  )
-}
-
 // Store
 const store = useTodosStore()
 // Store: Actions
-const { updateTodoDescription } = store
+const { incrementTodoCount } = store
 </script>
 
 <template lang="pug">
 span
-  | count:{{ count }}
+  | count:{{ todo.count }}
   |
-  TntButton.btn-none.align-text-top(@click="increment()")
+  TntButton.btn-none.align-text-top(@click="incrementTodoCount(todo.id, parent)")
     Icon(name="fa:plus")
 </template>

--- a/packages/app/components/TodoCount.vue
+++ b/packages/app/components/TodoCount.vue
@@ -1,11 +1,27 @@
 <script setup>
+import { useTodosStore } from '@/stores/todos'
+
 const props = defineProps([
-  'modelValue'
+  'value',
+  'todo',
+  'parent',
 ])
 
-const count = ref(props.modelValue)
+const count = ref(props.value)
 
-const increment = () => count.value++
+const increment = () => {
+  count.value++
+  updateTodoDescription(
+    props.todo.id,
+    `${props.todo.description}`.replace(/count:[^\s:]+/, `count:${count.value}`),
+    props.parent
+  )
+}
+
+// Store
+const store = useTodosStore()
+// Store: Actions
+const { updateTodoDescription } = store
 </script>
 
 <template lang="pug">

--- a/packages/app/components/TodoCount.vue
+++ b/packages/app/components/TodoCount.vue
@@ -1,0 +1,17 @@
+<script setup>
+const props = defineProps([
+  'modelValue'
+])
+
+const count = ref(props.modelValue)
+
+const increment = () => count.value++
+</script>
+
+<template lang="pug">
+span
+  | count:{{ count }}
+  |
+  TntButton.btn-none.align-text-top(@click="increment()")
+    Icon(name="fa:plus")
+</template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -1,0 +1,38 @@
+<script setup>
+import markdownit from 'markdown-it'
+
+const md = markdownit({
+  html: true,
+  linkify: true,
+})
+
+var defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
+  return self.renderToken(tokens, idx, options)
+}
+
+md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+  // Set target="_blank" on links unless they start with mailto
+  if (!/^mailto:/.test(tokens[idx].attrGet('href'))) tokens[idx].attrSet('target', '_blank')
+
+  // Pass the token to the default renderer.
+  return defaultRender(tokens, idx, options, env, self)
+}
+
+const props = defineProps([
+  'description'
+])
+
+const decorated = computed(() => {
+  return md.renderInline(
+    props.description
+      .replace(/(?<=^|\s)(\@\S+)/, '<span class="context-span">$1</span>')
+      .replace(/(?<=^|\s)(\+\S+)/, '<span class="project-span">$1</span>')
+      .replace(/(?<=^|\s)(\#\S+)/, '<span class="hashtag-span">$1</span>')
+      .replace(/(?<=^|\s)(\w+(?<!https?|mailto):[^\s:]+)/, '<span class="tag-span">$1</span>')
+  )
+})
+</script>
+
+<template lang="pug">
+span.prose.prose-lg(v-html="decorated")
+</template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -19,7 +19,9 @@ md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
 }
 
 const props = defineProps([
-  'description'
+  'description',
+  'todo',
+  'parent'
 ])
 
 const decorated = computed(() => {
@@ -45,7 +47,7 @@ const decorated = computed(() => {
 <template lang="pug">
 span
   template(v-for="item in decorated")
-    TodoCount.count-span(v-if="/^count:[^\s:]+$/.test(item)" v-model="item.match(/count:([^\s:]+)/)[1]")
-    TodoTime.time-span(v-else-if="/^time:[^\s:]+$/.test(item)" v-model="item.match(/time:([^\s:]+)/)[1]")
+    TodoCount.count-span(v-if="/^count:[^\s:]+$/.test(item)" :value="item.match(/count:([^\s:]+)/)[1]" :todo="todo" :parent="parent")
+    TodoTime.time-span(v-else-if="/^time:[^\s:]+$/.test(item)" :value="item.match(/time:([^\s:]+)/)[1]" :todo="todo" :parent="parent")
     span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -23,16 +23,29 @@ const props = defineProps([
 ])
 
 const decorated = computed(() => {
+  // Basic regexes for potentially matching/stripping Markdown prior to description splitting.
+  // const code = /(``.*?``|`.*?`)/g
+  // const bold = /([*_]{2}.*?[*_]{2})/g
+  // const emphasis = /([*_].*?[*_])/g
+  // const link = /(\[.*?\]\(.*?\))/g
+  // const linkAlt = /(<?(?:https?|mailto):\S+>?)/g
+
   return md.renderInline(
     props.description
       .replace(/(?<=^|\s)(\@\S+)/, '<span class="context-span">$1</span>')
       .replace(/(?<=^|\s)(\+\S+)/, '<span class="project-span">$1</span>')
       .replace(/(?<=^|\s)(\#\S+)/, '<span class="hashtag-span">$1</span>')
-      .replace(/(?<=^|\s)(\w+(?<!https?|mailto):[^\s:]+)/, '<span class="tag-span">$1</span>')
-  )
+      .replace(/(?<=^|\s)(every:[^\s:]+)/, '<span class="every-span">$1</span>')
+      .replace(/(?<=^|\s)(\w+(?<!https?|mailto|count|time):[^\s:]+)/, '<span class="tag-span">$1</span>')
+  ).split(/(?<=^|\s)((?:count|time):[^\s:]+)/g).filter(n => n)
+
 })
 </script>
 
 <template lang="pug">
-span.prose.prose-lg(v-html="decorated")
+span
+  template(v-for="item in decorated")
+    TodoCount.count-span(v-if="/^count:[^\s:]+$/.test(item)" v-model="item.match(/count:([^\s:]+)/)[1]")
+    TodoTime.time-span(v-else-if="/^time:[^\s:]+$/.test(item)" v-model="item.match(/time:([^\s:]+)/)[1]")
+    span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -37,8 +37,8 @@ const decorated = computed(() => {
       .replace(/(?<=^|\s)(\@\S+)/, '<span class="context-span">$1</span>')
       .replace(/(?<=^|\s)(\+\S+)/, '<span class="project-span">$1</span>')
       .replace(/(?<=^|\s)(\#\S+)/, '<span class="hashtag-span">$1</span>')
-      .replace(/(?<=^|\s)(every:[^ :]+)/, '<span class="every-span">$1</span>')
-      .replace(/(?<=^|\s)(\w+(?<!https?|mailto|count|time):[^ :]+)/, '<span class="tag-span">$1</span>')
+      .replace(/(?<=^|\s)(every:[^ :]+)/, '<span class="every-span text-nowrap">$1</span>')
+      .replace(/(?<=^|\s)(\w+(?<!https?|mailto|count|time):[^ :]+)/, '<span class="tag-span text-nowrap">$1</span>')
   ).split(/(?<=^|\s)((?:count|time):[^ :]+)/g).filter(n => n)
 
 })
@@ -47,7 +47,7 @@ const decorated = computed(() => {
 <template lang="pug">
 span
   template(v-for="item in decorated")
-    TodoCount.count-span(v-if="/^count:[^ :]+$/.test(item)" :value="item.match(/count:([^ :]+)/)[1]" :todo="todo" :parent="parent")
-    TodoTime.time-span(v-else-if="/^time:[^ :]+$/.test(item)" :value="item.match(/time:([^ :]+)/)[1]" :todo="todo" :parent="parent")
+    TodoCount.count-span.text-nowrap(v-if="/^count:[^ :]+$/.test(item)" :value="item.match(/count:([^ :]+)/)[1]" :todo="todo" :parent="parent")
+    TodoTime.time-span.text-nowrap(v-else-if="/^time:[^ :]+$/.test(item)" :value="item.match(/time:([^ :]+)/)[1]" :todo="todo" :parent="parent")
     span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -47,7 +47,7 @@ const decorated = computed(() => {
 <template lang="pug">
 span
   template(v-for="item in decorated")
-    TodoCount.count-span.text-nowrap(v-if="/^count:[^ :]+$/.test(item)" :value="item.match(/count:([^ :]+)/)[1]" :todo="todo" :parent="parent")
+    TodoCount.count-span.text-nowrap(v-if="/^count:[^ :]+$/.test(item)" :todo="todo" :parent="parent")
     TodoTime.time-span.text-nowrap(v-else-if="/^time:[^ :]+$/.test(item)" :todo="todo" :parent="parent")
     span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -48,6 +48,6 @@ const decorated = computed(() => {
 span
   template(v-for="item in decorated")
     TodoCount.count-span.text-nowrap(v-if="/^count:[^ :]+$/.test(item)" :value="item.match(/count:([^ :]+)/)[1]" :todo="todo" :parent="parent")
-    TodoTime.time-span.text-nowrap(v-else-if="/^time:[^ :]+$/.test(item)" :value="item.match(/time:([^ :]+)/)[1]" :todo="todo" :parent="parent")
+    TodoTime.time-span.text-nowrap(v-else-if="/^time:[^ :]+$/.test(item)" :todo="todo" :parent="parent")
     span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoDescription.vue
+++ b/packages/app/components/TodoDescription.vue
@@ -37,9 +37,9 @@ const decorated = computed(() => {
       .replace(/(?<=^|\s)(\@\S+)/, '<span class="context-span">$1</span>')
       .replace(/(?<=^|\s)(\+\S+)/, '<span class="project-span">$1</span>')
       .replace(/(?<=^|\s)(\#\S+)/, '<span class="hashtag-span">$1</span>')
-      .replace(/(?<=^|\s)(every:[^\s:]+)/, '<span class="every-span">$1</span>')
-      .replace(/(?<=^|\s)(\w+(?<!https?|mailto|count|time):[^\s:]+)/, '<span class="tag-span">$1</span>')
-  ).split(/(?<=^|\s)((?:count|time):[^\s:]+)/g).filter(n => n)
+      .replace(/(?<=^|\s)(every:[^ :]+)/, '<span class="every-span">$1</span>')
+      .replace(/(?<=^|\s)(\w+(?<!https?|mailto|count|time):[^ :]+)/, '<span class="tag-span">$1</span>')
+  ).split(/(?<=^|\s)((?:count|time):[^ :]+)/g).filter(n => n)
 
 })
 </script>
@@ -47,7 +47,7 @@ const decorated = computed(() => {
 <template lang="pug">
 span
   template(v-for="item in decorated")
-    TodoCount.count-span(v-if="/^count:[^\s:]+$/.test(item)" :value="item.match(/count:([^\s:]+)/)[1]" :todo="todo" :parent="parent")
-    TodoTime.time-span(v-else-if="/^time:[^\s:]+$/.test(item)" :value="item.match(/time:([^\s:]+)/)[1]" :todo="todo" :parent="parent")
+    TodoCount.count-span(v-if="/^count:[^ :]+$/.test(item)" :value="item.match(/count:([^ :]+)/)[1]" :todo="todo" :parent="parent")
+    TodoTime.time-span(v-else-if="/^time:[^ :]+$/.test(item)" :value="item.match(/time:([^ :]+)/)[1]" :todo="todo" :parent="parent")
     span(v-else v-html="item")
 </template>

--- a/packages/app/components/TodoItem.vue
+++ b/packages/app/components/TodoItem.vue
@@ -30,7 +30,7 @@ div.text-lg
       span.mr-1(v-if="todo.created" class="text-cyan-800 dark:text-cyan-300") {{ todo.created }}
       span.mr-1(v-if="todo.due" class="text-yellow-800 dark:text-yellow-300") {{ todo.due }}
       span.mr-1(v-if="todo.price" class="text-green-800 dark:text-green-300") {{ todo.price }}
-      span.prose.prose-lg(v-html="todo.decorated")
+      TodoDescription(:description="todo.description")
       span.ml-1(v-if="todo.multiplier" class="text-pink-800 dark:text-pink-300") x{{ todo.multiplier }}
     TntButton.btn-none(@click="deleteTodo(todo.id, parent)" class="text-danger-light hover:text-danger-light-hover dark:text-danger-dark dark:hover:text-danger-dark-hover")
       Icon(name="fa:trash")

--- a/packages/app/components/TodoItem.vue
+++ b/packages/app/components/TodoItem.vue
@@ -30,7 +30,7 @@ div.text-lg
       span.mr-1(v-if="todo.created" class="text-cyan-800 dark:text-cyan-300") {{ todo.created }}
       span.mr-1(v-if="todo.due" class="text-yellow-800 dark:text-yellow-300") {{ todo.due }}
       span.mr-1(v-if="todo.price" class="text-green-800 dark:text-green-300") {{ todo.price }}
-      TodoDescription(:description="todo.description")
+      TodoDescription(:description="todo.description" :todo="todo" :parent="parent")
       span.ml-1(v-if="todo.multiplier" class="text-pink-800 dark:text-pink-300") x{{ todo.multiplier }}
     TntButton.btn-none(@click="deleteTodo(todo.id, parent)" class="text-danger-light hover:text-danger-light-hover dark:text-danger-dark dark:hover:text-danger-dark-hover")
       Icon(name="fa:trash")

--- a/packages/app/components/TodoItem.vue
+++ b/packages/app/components/TodoItem.vue
@@ -87,4 +87,31 @@ div.text-lg
     dark:text-amber-500
     dark:bg-amber-950;
 }
+
+.count-span {
+  @apply
+    rounded
+    text-yellow-700
+    bg-yellow-50
+    dark:text-yellow-500
+    dark:bg-yellow-950;
+}
+
+.time-span {
+  @apply
+    rounded
+    text-lime-700
+    bg-lime-50
+    dark:text-lime-500
+    dark:bg-lime-950;
+}
+
+.every-span {
+  @apply
+    rounded
+    text-purple-700
+    bg-purple-50
+    dark:text-purple-500
+    dark:bg-purple-950;
+}
 </style>

--- a/packages/app/components/TodoItem.vue
+++ b/packages/app/components/TodoItem.vue
@@ -12,13 +12,13 @@ const props = defineProps({
 // Store
 const store = useTodosStore()
 // Store: Actions
-const { toggleTodo, toggleTodoFocus, deleteTodo } = store
+const { toggleTodoDone, toggleTodoFocus, deleteTodo } = store
 </script>
 
 <template lang="pug">
 div.text-lg
   .flex.space-x-2(:class="todo.status === 'focus' ? 'font-bold' : todo.status === 'done' ? 'toodles-done' : todo.status === 'obsolete' ? 'toodles-obsolete' : ''")
-    TntButton.btn-none(@click="toggleTodo(todo.id, parent)")
+    TntButton.btn-none(@click="toggleTodoDone(todo.id, parent)")
       Icon(v-if="todo.status === 'done'" name="fa:check-square")
       Icon(v-else-if="todo.status === 'obsolete'" name="fa:minus-square")
       Icon(v-else name="fa:square")

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -1,11 +1,27 @@
 <script setup>
+import { useTodosStore } from '@/stores/todos'
+
 const props = defineProps([
-  'modelValue'
+  'value',
+  'todo',
+  'parent',
 ])
 
-const time = ref(props.modelValue)
+const time = ref(props.value)
 
-const increment = () => time.value++
+const increment = () => {
+  time.value++
+  updateTodoDescription(
+    props.todo.id,
+    `${props.todo.description}`.replace(/time:[^\s:]+/, `time:${time.value}`),
+    props.parent
+  )
+}
+
+// Store
+const store = useTodosStore()
+// Store: Actions
+const { updateTodoDescription } = store
 </script>
 
 <template lang="pug">

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -60,6 +60,10 @@ const stopTimer = () => {
   )
 }
 
+onUnmounted(() => {
+  clearInterval(tick)
+})
+
 // Store
 const store = useTodosStore()
 // Store: Actions

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -1,82 +1,24 @@
 <script setup>
 import { useTodosStore } from '@/stores/todos'
 
-import dayjs from 'dayjs'
-import { default as dayjsDuration } from 'dayjs/plugin/duration'
-dayjs.extend(dayjsDuration)
-
 const props = defineProps([
-  'value',
   'todo',
   'parent',
 ])
 
-const time = ref(props.value)
-
-const startedAt = ref(null)
-
-const duration = computed(() => {
-  let milliseconds = 0
-  const hours = time.value.match(/(\d+)h/)
-  const minutes = time.value.match(/(\d+)m/)
-  const seconds = time.value.match(/(\d+)s/)
-  if (hours) milliseconds += parseInt(hours[1]) * 3_600_000
-  if (minutes) milliseconds += parseInt(minutes[1]) * 60_000
-  if (seconds) milliseconds += parseInt(seconds[1]) * 1_000
-  return dayjs.duration(milliseconds)
-})
-
-const toString = computed(() => {
-  return duration.value.format('H[h]m[m]')
-})
-
-const tick = ref(null)
-const lastTick = ref(null)
-const activeDuration = ref(dayjs.duration(0))
-
-const startTimer = () => {
-  startedAt.value = dayjs(new Date())
-  activeDuration.value = duration.value
-  lastTick.value ||= startedAt.value
-
-  tick.value = setInterval(() => {
-    const current = dayjs(new Date())
-    const durSinceLastTick = dayjs.duration(current.diff(lastTick.value))
-    activeDuration.value = activeDuration.value.add(durSinceLastTick)
-    time.value = activeDuration.value.format('H[h]m[m]')
-    lastTick.value = current
-  }, 1000)
-}
-
-const stopTimer = () => {
-  clearInterval(tick.value)
-  startedAt.value = null
-  activeDuration.value = dayjs.duration(0)
-  updateTodoDescription(
-    props.todo.id,
-    `${props.todo.description}`.replace(/time:[^\s:]+/, `time:${toString.value}`),
-    props.parent
-  )
-}
-
-onUnmounted(() => {
-  clearInterval(tick)
-})
-
 // Store
 const store = useTodosStore()
 // Store: Actions
-const { updateTodoDescription } = store
+const { toggleTodoTimer } = store
 </script>
 
 <template lang="pug">
-span(:class="startedAt ? 'is-active' : ''")
-  | time:{{ time }}
+span(:class="todo.isActive ? 'is-active' : ''")
+  | time:{{ todo.timer }}
   |
-  TntButton.btn-none.align-text-top(v-if="!startedAt" @click="startTimer()")
-    Icon(name="fa:play")
-  TntButton.btn-none.align-text-top(v-if="startedAt" @click="stopTimer()")
-    Icon(name="fa:pause")
+  TntButton.btn-none.align-text-top(@click="toggleTodoTimer(todo.id, parent)")
+    Icon(v-if="!todo.isActive" name="fa:play")
+    Icon(v-else name="fa:pause")
 </template>
 
 <style lang="postcss">

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -27,20 +27,24 @@ const duration = computed(() => {
 })
 
 const toString = computed(() => {
-  return duration.value.format('H[h]m[m]s[s]')
+  return duration.value.format('H[h]m[m]')
 })
 
 let tick
 
 const lastTick = ref(null)
+const activeDuration = ref(dayjs.duration(0))
 
 const startTimer = () => {
   startedAt.value = dayjs(new Date())
+  activeDuration.value = duration.value
   lastTick.value = startedAt.value
+
   tick = setInterval(() => {
     const current = dayjs(new Date())
     const durSinceLastTick = dayjs.duration(current.diff(lastTick.value))
-    time.value = duration.value.add(durSinceLastTick).format('H[h]m[m]s[s]')
+    activeDuration.value = activeDuration.value.add(durSinceLastTick)
+    time.value = activeDuration.value.format('H[h]m[m]')
     lastTick.value = current
   }, 1000)
 }
@@ -48,6 +52,7 @@ const startTimer = () => {
 const stopTimer = () => {
   clearInterval(tick)
   startedAt.value = null
+  activeDuration.value = dayjs.duration(0)
   updateTodoDescription(
     props.todo.id,
     `${props.todo.description}`.replace(/time:[^\s:]+/, `time:${toString.value}`),

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -1,6 +1,11 @@
 <script setup>
 import { useTodosStore } from '@/stores/todos'
 
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
+dayjs.extend(duration)
+
 const props = defineProps([
   'value',
   'todo',
@@ -9,11 +14,35 @@ const props = defineProps([
 
 const time = ref(props.value)
 
-const increment = () => {
-  time.value++
+const startedAt = ref(null)
+
+const dur = computed(() => {
+  let milliseconds = 0
+  const hours = time.value.match(/(\d+)h/)
+  const minutes = time.value.match(/(\d+)m/)
+  const seconds = time.value.match(/(\d+)s/)
+  if (hours) milliseconds += parseInt(hours[1]) * 3_600_000
+  if (minutes) milliseconds += parseInt(minutes[1]) * 60_000
+  if (seconds) milliseconds += parseInt(seconds[1]) * 1_000
+  return dayjs.duration(milliseconds)
+})
+
+const toString = computed(() => {
+  return dur.value.format('H[h]m[m]s[s]')
+})
+
+const startTimer = () => {
+  startedAt.value = dayjs(new Date())
+}
+
+const stopTimer = () => {
+  const endedAt = dayjs(new Date)
+  const durSinceStart = dayjs.duration(endedAt.diff(startedAt.value))
+  time.value = dur.value.add(durSinceStart).format('H[h]m[m]s[s]')
+  startedAt.value = null
   updateTodoDescription(
     props.todo.id,
-    `${props.todo.description}`.replace(/time:[^\s:]+/, `time:${time.value}`),
+    `${props.todo.description}`.replace(/time:[^\s:]+/, `time:${toString.value}`),
     props.parent
   )
 }
@@ -25,9 +54,21 @@ const { updateTodoDescription } = store
 </script>
 
 <template lang="pug">
-span
+span(:class="startedAt ? 'is-active' : ''")
   | time:{{ time }}
   |
-  TntButton.btn-none.align-text-top(@click="increment()")
+  TntButton.btn-none.align-text-top(v-if="!startedAt" @click="startTimer()")
     Icon(name="fa:play")
+  TntButton.btn-none.align-text-top.animate-pulse(v-if="startedAt" @click="stopTimer()")
+    Icon(name="fa:pause")
 </template>
+
+<style lang="postcss">
+span.is-active {
+  @apply
+    text-orange-700
+    bg-orange-50
+    dark:text-orange-500
+    dark:bg-orange-950;
+}
+</style>

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -1,0 +1,17 @@
+<script setup>
+const props = defineProps([
+  'modelValue'
+])
+
+const time = ref(props.modelValue)
+
+const increment = () => time.value++
+</script>
+
+<template lang="pug">
+span
+  | time:{{ time }}
+  |
+  TntButton.btn-none.align-text-top(@click="increment()")
+    Icon(name="fa:play")
+</template>

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -31,14 +31,23 @@ const toString = computed(() => {
   return dur.value.format('H[h]m[m]s[s]')
 })
 
+let tick
+
+const lastTick = ref(null)
+
 const startTimer = () => {
   startedAt.value = dayjs(new Date())
+  lastTick.value = startedAt.value
+  tick = setInterval(() => {
+    const current = dayjs(new Date())
+    const durSinceLastTick = dayjs.duration(current.diff(lastTick.value))
+    time.value = dur.value.add(durSinceLastTick).format('H[h]m[m]s[s]')
+    lastTick.value = current
+  }, 1000)
 }
 
 const stopTimer = () => {
-  const endedAt = dayjs(new Date)
-  const durSinceStart = dayjs.duration(endedAt.diff(startedAt.value))
-  time.value = dur.value.add(durSinceStart).format('H[h]m[m]s[s]')
+  clearInterval(tick)
   startedAt.value = null
   updateTodoDescription(
     props.todo.id,
@@ -59,16 +68,13 @@ span(:class="startedAt ? 'is-active' : ''")
   |
   TntButton.btn-none.align-text-top(v-if="!startedAt" @click="startTimer()")
     Icon(name="fa:play")
-  TntButton.btn-none.align-text-top.animate-pulse(v-if="startedAt" @click="stopTimer()")
+  TntButton.btn-none.align-text-top(v-if="startedAt" @click="stopTimer()")
     Icon(name="fa:pause")
 </template>
 
 <style lang="postcss">
 span.is-active {
   @apply
-    text-orange-700
-    bg-orange-50
-    dark:text-orange-500
-    dark:bg-orange-950;
+    animate-pulse;
 }
 </style>

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -30,17 +30,16 @@ const toString = computed(() => {
   return duration.value.format('H[h]m[m]')
 })
 
-let tick
-
+const tick = ref(null)
 const lastTick = ref(null)
 const activeDuration = ref(dayjs.duration(0))
 
 const startTimer = () => {
   startedAt.value = dayjs(new Date())
   activeDuration.value = duration.value
-  lastTick.value = startedAt.value
+  lastTick.value ||= startedAt.value
 
-  tick = setInterval(() => {
+  tick.value = setInterval(() => {
     const current = dayjs(new Date())
     const durSinceLastTick = dayjs.duration(current.diff(lastTick.value))
     activeDuration.value = activeDuration.value.add(durSinceLastTick)
@@ -50,7 +49,7 @@ const startTimer = () => {
 }
 
 const stopTimer = () => {
-  clearInterval(tick)
+  clearInterval(tick.value)
   startedAt.value = null
   activeDuration.value = dayjs.duration(0)
   updateTodoDescription(

--- a/packages/app/components/TodoTime.vue
+++ b/packages/app/components/TodoTime.vue
@@ -2,9 +2,8 @@
 import { useTodosStore } from '@/stores/todos'
 
 import dayjs from 'dayjs'
-import duration from 'dayjs/plugin/duration'
-
-dayjs.extend(duration)
+import { default as dayjsDuration } from 'dayjs/plugin/duration'
+dayjs.extend(dayjsDuration)
 
 const props = defineProps([
   'value',
@@ -16,7 +15,7 @@ const time = ref(props.value)
 
 const startedAt = ref(null)
 
-const dur = computed(() => {
+const duration = computed(() => {
   let milliseconds = 0
   const hours = time.value.match(/(\d+)h/)
   const minutes = time.value.match(/(\d+)m/)
@@ -28,7 +27,7 @@ const dur = computed(() => {
 })
 
 const toString = computed(() => {
-  return dur.value.format('H[h]m[m]s[s]')
+  return duration.value.format('H[h]m[m]s[s]')
 })
 
 let tick
@@ -41,7 +40,7 @@ const startTimer = () => {
   tick = setInterval(() => {
     const current = dayjs(new Date())
     const durSinceLastTick = dayjs.duration(current.diff(lastTick.value))
-    time.value = dur.value.add(durSinceLastTick).format('H[h]m[m]s[s]')
+    time.value = duration.value.add(durSinceLastTick).format('H[h]m[m]s[s]')
     lastTick.value = current
   }, 1000)
 }

--- a/packages/app/models/Todo.ts
+++ b/packages/app/models/Todo.ts
@@ -1,22 +1,4 @@
 import { uniqueId as _uniqueId } from 'lodash'
-import markdownit from 'markdown-it'
-
-const md = markdownit({
-  html: true,
-  linkify: true,
-})
-
-var defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
-  return self.renderToken(tokens, idx, options)
-}
-
-md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-  // Set target="_blank" on links unless they start with mailto
-  if (!/^mailto:/.test(tokens[idx].attrGet('href'))) tokens[idx].attrSet('target', '_blank')
-
-  // Pass the token to the default renderer.
-  return defaultRender(tokens, idx, options, env, self)
-}
 
 interface TodoInterface {
   id?: string
@@ -120,16 +102,6 @@ export class Todo implements TodoInterface {
     this.multiplier = parent.match(/(?<=\bx)(\d+)(?=$)/)?.[1]
 
     this.children = children.map((c) => new Todo(c))
-  }
-
-  get decorated() {
-    return md.renderInline(
-      this.description
-        .replace(/(?:^|\s)(\@\S+)/, '<span class="context-span">$1</span>')
-        .replace(/(?:^|\s)(\+\S+)/, '<span class="project-span">$1</span>')
-        .replace(/(?:^|\s)(\#\S+)/, '<span class="hashtag-span">$1</span>')
-        .replace(/(?:^|\s)(\w+(?<!https?|mailto):[^\s:]+)/, '<span class="tag-span">$1</span>')
-    )
   }
 
   get status() {

--- a/packages/app/models/Todo.ts
+++ b/packages/app/models/Todo.ts
@@ -39,6 +39,9 @@ export class Todo implements TodoInterface {
   // tokens?: string[] // We are not yet implementing search
   children?: Todo[]
 
+  // Count
+  count?: number
+
   // Timer
   timer?: string
   // Timer utilities
@@ -64,6 +67,7 @@ export class Todo implements TodoInterface {
       this.multiplier = todo.multiplier || undefined
       this.children = this.children || undefined
     }
+    this.count = Number(this.description.match(/count:(\d+)/)?.[1])
     this.timer = this.description.match(/time:([^ :]+)/)?.[1]
     this.setTags()
   }
@@ -174,6 +178,11 @@ export class Todo implements TodoInterface {
       this.state = '!'
       this.completed = undefined
     }
+  }
+
+  incrementCount() {
+    if (this.count) this.count++
+    this.description = `${this.description}`.replace(/count:[^: ]+/, `count:${this.count}`)
   }
 
   toggleTimer() {

--- a/packages/app/models/Todo.ts
+++ b/packages/app/models/Todo.ts
@@ -121,7 +121,7 @@ export class Todo implements TodoInterface {
   }
 
   // Instance methods: Actions
-  toggle() {
+  toggleDone() {
     var currentDate = new Date().toISOString().substring(0, 10)
     if (this.status === 'done') {
       this.state = '*'

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -10,6 +10,7 @@
     "electron:dev": "ELECTRON=true nuxt dev"
   },
   "dependencies": {
+    "dayjs": "^1.11.12",
     "markdown-it": "^14.1.0"
   },
   "devDependencies": {

--- a/packages/app/pages/index.vue
+++ b/packages/app/pages/index.vue
@@ -52,5 +52,5 @@ div
 
   ul.space-y-2
     li(v-for="item in todos")
-      TodoItem(:todo="item")
+      TodoItem(:todo="item" :key="`todo-${item.id}`")
 </template>

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -39,6 +39,12 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
+  function updateTodoDescription(id: string, description: string, parent?: string) {
+    const todo = find.value(id, parent)
+    if (todo) todo.description = description
+    useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
+  }
+
   function toggleTodo(id: string, parent?: string) {
     const todo = find.value(id, parent)
     if (todo) todo.toggle()
@@ -64,5 +70,5 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
-  return { list, all, progress, fetchTodos, addTodo, toggleTodo, toggleTodoFocus, deleteTodo }
+  return { list, all, progress, fetchTodos, addTodo, updateTodoDescription, toggleTodo, toggleTodoFocus, deleteTodo }
 })

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -70,5 +70,18 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
-  return { list, all, progress, fetchTodos, addTodo, updateTodoDescription, toggleTodo, toggleTodoFocus, deleteTodo }
+  return {
+    // State
+    list,
+    // Getters
+    all,
+    progress,
+    // Actions
+    fetchTodos,
+    addTodo,
+    updateTodoDescription,
+    toggleTodo,
+    toggleTodoFocus,
+    deleteTodo
+  }
 })

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -41,36 +41,37 @@ export const useTodosStore = defineStore('todos', () => {
 
   function updateTodoDescription(id: string, description: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) todo.description = description
+    if (!todo) return
+    todo.description = description
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
   function toggleTodoDone(id: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) todo.toggleDone()
+    if (!todo) return
+    todo.toggleDone()
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
   function toggleTodoFocus(id: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) todo.toggleFocus()
+    if (!todo) return
+    todo.toggleFocus()
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
   function incrementTodoCount(id: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) {
-      todo.incrementCount()
-      useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
-    }
+    if (!todo) return
+    todo.incrementCount()
+    useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
   function toggleTodoTimer(id: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) {
-      todo.toggleTimer()
-      if(!todo.isActive) useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
-    }
+    if (!todo) return
+    todo.toggleTimer()
+    if(!todo.isActive) useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
   function deleteTodo(id: string, parent?: string) {

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -57,6 +57,14 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
+  function toggleTodoTimer(id: string, parent?: string) {
+    const todo = find.value(id, parent)
+    if (todo) {
+      todo.toggleTimer()
+      if(!todo.isActive) useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
+    }
+  }
+
   function deleteTodo(id: string, parent?: string) {
     let parentTodo
     if (parent) parentTodo = list.value.find(t => t.id === parent)
@@ -82,6 +90,7 @@ export const useTodosStore = defineStore('todos', () => {
     updateTodoDescription,
     toggleTodoDone,
     toggleTodoFocus,
+    toggleTodoTimer,
     deleteTodo
   }
 })

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -45,9 +45,9 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
-  function toggleTodo(id: string, parent?: string) {
+  function toggleTodoDone(id: string, parent?: string) {
     const todo = find.value(id, parent)
-    if (todo) todo.toggle()
+    if (todo) todo.toggleDone()
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
@@ -80,7 +80,7 @@ export const useTodosStore = defineStore('todos', () => {
     fetchTodos,
     addTodo,
     updateTodoDescription,
-    toggleTodo,
+    toggleTodoDone,
     toggleTodoFocus,
     deleteTodo
   }

--- a/packages/app/stores/todos.ts
+++ b/packages/app/stores/todos.ts
@@ -57,6 +57,14 @@ export const useTodosStore = defineStore('todos', () => {
     useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
   }
 
+  function incrementTodoCount(id: string, parent?: string) {
+    const todo = find.value(id, parent)
+    if (todo) {
+      todo.incrementCount()
+      useTntApi().updateFile('todo.txt', Todo.toFile(list.value))
+    }
+  }
+
   function toggleTodoTimer(id: string, parent?: string) {
     const todo = find.value(id, parent)
     if (todo) {
@@ -90,6 +98,7 @@ export const useTodosStore = defineStore('todos', () => {
     updateTodoDescription,
     toggleTodoDone,
     toggleTodoFocus,
+    incrementTodoCount,
     toggleTodoTimer,
     deleteTodo
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,6 +6380,11 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.11.12:
+  version "1.11.12"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.12.tgz#5245226cc7f40a15bf52e0b99fd2a04669ccac1d"
+  integrity sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==
+
 db0@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/db0/-/db0-0.1.4.tgz#8df1d9600b812bad0b4129ccbbb7f1b8596a5817"


### PR DESCRIPTION
closes #115 with some changes

We've gone with `count:` and `time:` as key values for our interactive tags, and we've gone with `every:` for now for defining repetition rules (but this is not yet implemented - will handle on separate issue).

This all feels the most semantically clear when parsing the text with your own eyes...

```
! Send out invites count:12
(A) Add interactive tags to #Toodles estimate:3h time:2h37m
Take out the recycling every:Wednesday
```

_Note that `time:` tag does not respect the presence of an `estimate:` tag (maybe one day it will) and we still haven't implemented a target value for the `count:` tag either (e.g. `count:12/30`). But you could, as with my example including `estimate:` above, just denote this with your own custom tag:_

```
! Send out invites count:12 of:30
```

We can't determine anyway whether your target value is a hard limit or a soft target, so doing anything additional to style the `count:` tag based on proximity may not be desirable. Still, we might implement support for a target value of the form `count:12/30` in the near future, even if we don't do anything in response to exceeding that value.

As for `every:`, as I said we'll handle that separately. `every:` needs to trigger a response when the item is checked off. The item should probably also have a due date. Our rules will be pretty basic... When you check an item off, if that item has `every:` tag find the next valid date and create a new item that is a clone of this one with the due date updated for that future date.

_But we still need to settle on a schedule syntax before handling that. I do like the idea of supporting... `every:Tuesday` (which finds the next Tuesday), `every:Week` (which finds the date one week from the current due date), but then we get to months and things get a little more complex... so maybe those are just conveniences I add in, and the more expansive syntax is one which already exists and fits the spec. Maybe._

By submitting this pull request, you agree to follow our Code of Conduct: https://github.com/thombruce/.github/blob/main/CODE_OF_CONDUCT.md

---

_Internal use. Do not delete._

- [ ] Tests passing
- [ ] Coverage sufficient
- [ ] Manual review
- [ ] No A11y regression
- [ ] Translations provided or not needed
